### PR TITLE
Pulls 'faceoffs' state from redux store correctly

### DIFF
--- a/src/components/pages/VotingPage/VotingPageContainer.js
+++ b/src/components/pages/VotingPage/VotingPageContainer.js
@@ -75,7 +75,7 @@ function VotingPageContainer({ LoadingComponent, ...props }) {
 export default connect(
   state => ({
     child: state.child,
-    faceoffs: state.faceoff,
+    faceoffs: state.faceoffs,
   }),
   {}
 )(VotingPageContainer);


### PR DESCRIPTION
# Description

Fixed a typo when pulling _**faceoffs**_ state from the redux store.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [ ] No
- [x] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
