### PR TITLE
modify match-up page UI so the Vote button is more recognizable

### DIFF
--- a/src/styles/less/MatchUp.less
+++ b/src/styles/less/MatchUp.less
@@ -2,11 +2,11 @@
   position: relative;
 
   .question-icon {
-    font-size: 3rem;
-    color: white;
+    font-size: 2.1rem;
+    color: #6d6d6d;
     position: absolute;
-    top: 23%;
-    left: 95%;
+    top: 1.2%;
+    right: 4.5%;
   }
 
   .ant-row {
@@ -49,7 +49,7 @@
             img {
               margin-right: 0.5vw;
             }
-            .name{
+            .name {
               font-family: bangers;
               font-size: x-large;
             }
@@ -65,7 +65,7 @@
               width: 100%;
               height: 57%;
               border-radius: 20px;
-              border: 3px solid black; 
+              border: 3px solid black;
             }
           }
         }
@@ -91,23 +91,33 @@
 
   .back-button {
     .orangeButtonStyle();
+    border-color: #ddd;
     position: absolute;
     width: 7%;
     height: 6.5%;
     font-weight: 700;
-    left: 2vh;
-    bottom: 2vh;
+    left: 4vw;
+    top: -7vh;
     text-shadow: -2px 0 black, 0 2px black, 2px 0 black, 0 -2px black;
   }
 
   .vote-button {
-    .orangeButtonStyle();
+    color: #fff;
+    box-sizing: border-box;
+    font-size: 1.1rem;
+    line-height: 1.1rem;
+    border: 3px solid #ddd;
+    background-color: #20c997;
     position: absolute;
     width: 7%;
     height: 6.5%;
-    right: 2vh;
-    bottom: 2vh;
+    right: 4vw;
+    top: -7vh;
     font-weight: 700;
     text-shadow: -2px 0 black, 0 2px black, 2px 0 black, 0 -2px black;
+
+    &:hover {
+      background-color: #4dd4ac;
+    }
   }
 }

--- a/src/styles/less/PointShare.less
+++ b/src/styles/less/PointShare.less
@@ -112,9 +112,9 @@
   }
 }
 .question-icon {
-  font-size: 3rem;
-  color: white;
+  font-size: 2.1rem;
+  color: #6d6d6d;
   position: absolute;
-  top: 23%;
-  left: 95%;
+  top: 1.2%;
+  right: 4.5%;
 }


### PR DESCRIPTION
# Description

After talking to the stakeholders, we have decided to change the UI of the match-up page, so it is less confusing for the user that the Vote button is not for the last tile in the page. The location of the buttons, and relocation of the question button was decided by the stakeholders as well. 

I will attach a screenshot in a comment.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
